### PR TITLE
support more protocols

### DIFF
--- a/src/git_open/git_open.py
+++ b/src/git_open/git_open.py
@@ -55,8 +55,7 @@ class GitOpen(object):
         origin_line = re.sub("^origin", "", origin_line)
 
         # Remove protocols
-        origin_line = re.sub("http://", "", origin_line)
-        origin_line = re.sub("ssh://", "", origin_line)
+        origin_line = re.sub("[A-Za-z0-9][A-Za-z0-9+.-]*://", "", origin_line)
 
         origin_line = re.sub("\.git.*$", "", origin_line)
         origin_line = re.sub("\(.*\)", "", origin_line)

--- a/tests/test_git_open.py
+++ b/tests/test_git_open.py
@@ -78,6 +78,10 @@ def test_get_origin_line(test_input, expected):
             "origin	ssh://git@gitlab.some-domain.com:2222/user/some-repo.git (fetch)",
             "git@gitlab.some-domain.com:2222/user/some-repo",
         ),
+        (
+            "origin	git+ssh://git@gitlab.some-domain.com:2222/user/some-repo.git (fetch)",
+            "git@gitlab.some-domain.com:2222/user/some-repo",
+        ),
     ],
 )
 def test_filter_origin_line(test_input, expected):


### PR DESCRIPTION
I don't know why I have remotes with the git+ssh:// scheme/protocol.
But this makes them work.

Here is some info on git supported urls and the source of the regexp:
https://stackoverflow.com/a/31801532.